### PR TITLE
Fix ORCID link

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Meta-Package for the Epiverse-TRACE Project
 Version: 0.0.1
 Authors@R: 
     person("Hugo", "Gruson", , "hugo@data.org", role = c("aut", "cre"),
-           comment = c(ORCID = "https://orcid.org/0000-0002-4094-1476"))
+           comment = c(ORCID = "0000-0002-4094-1476"))
 Description: Your package description. It must end with a period (".") and
     include relevant bibliographical references if applicable, using the
     following format: Author et al. (2023) <doi:10.5281/zenodo.6619350>.


### PR DESCRIPTION
This PR fixes the ORCID links for the `pkgdown` page. See also upstream change to the template - https://github.com/epiverse-trace/packagetemplate/pull/126