### PR TITLE
Add cron schedule to R CMD check workflow

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -7,6 +7,8 @@
 # rcmdcheck::rcmdcheck()
 # ```
 on:
+  schedule:
+    - cron: 15 12 * * 1
   push:
     branches: [main, master]
     paths:

--- a/man/epiverse-package.Rd
+++ b/man/epiverse-package.Rd
@@ -8,7 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-Your package description. It must end with a period (".") and include relevant bibliographical references if applicable, using the following format: Author et al. (2023) \doi{10.5281/zenodo.6619350}.
+A meta-package to provide easy access to all 'Epiverse-TRACE' packages released on CRAN. From a technical perspective, it is also where integration tests across packages are hosted, and where dependency scaffolding at the level of this ecosystem is investigated.
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [X] I have read the CONTRIBUTING guidelines
- [ ] A new item has been added to `NEWS.md`
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [X] Checks have been run locally and pass

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR addresses #8 by adding a schedule trigger to the `R-CMD-check.yaml` GitHub actions workflow. I have set the cron schedule to run weekly (on a Monday) and to run at quarter past midday (the schedule is not run on the hour given advice from [GitHub docs](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule)).

This change is made to ensure that interoperability breaking changes from developments in individual Epiverse-TRACE packages is caught without requiring manually triggering the {epiverse} R CMD check. 

Issue #8 mentions that a custom GitHub actions workflow could be added rather than running the entire R CMD check, but as this package is simple the check completes relatively quickly (tested locally).

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

The `epiverse-package.Rd` file is updated from re-rendering the package documentation from changes made in PR #10.