### PR TITLE
Add integration tests for {epiparameter} & {cfr}

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * The R CMD check GitHub actions workflow was set to run on at 12:15 on Monday via a cron schedule (#13).
 
-* Integration tests have been added to test interoperability between {simulist} and {cleanepi} (#7), and {epiparameter} and {simulist} (#14).
+* Integration tests have been added to test interoperability between {simulist} and {cleanepi} (#7), {epiparameter} and {simulist} (#14), and {epiparameter} and {cfr} (#18).
 
 * This project now includes a
    [`NEWS.md`](https://r-pkgs.org/other-markdown.html#sec-news) file to inform

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,4 +1,5 @@
 al
+cfr
 cleanepi
 CMD
 codecov

--- a/tests/testthat/test-epiparameter-cfr.R
+++ b/tests/testthat/test-epiparameter-cfr.R
@@ -1,0 +1,46 @@
+# load a single Ebola serial interval (SI) from {epiparameter} database
+ebola_si <- epiparameter_db(
+  disease = "Ebola",
+  epi_name = "serial interval",
+  single_epiparameter = TRUE
+)
+
+# check the Ebola SI selected is Gamma, this may change in future versions of
+# {epiparameter} with new entries in the database. The tests will have to be
+# updated if the distribution selected from the database changes.
+family(ebola_si)
+
+# get parameters from Ebola SI
+dist_params <- get_parameters(ebola_si)
+
+# load Ebola dataset from {cfr}
+data("ebola1976", package = "cfr")
+
+test_that("cfr_static is works with base and <epiparameter>", {
+  # calculate cfr using Ebola SI parameters with base density
+  cfr_base_density <- cfr_static(
+    data = ebola1976,
+    delay_density = function(x) {
+      dgamma(x, shape = dist_params[["shape"]], scale = dist_params[["scale"]])
+    }
+  )
+
+  # calculate cfr using Ebola SI parameters with <epiparameter> density
+  cfr_ep_density <- cfr_static(
+    data = ebola1976,
+    delay_density = function(x) {
+      density(ebola_si, at = x)
+    }
+  )
+
+  # calculate cfr using Ebola SI parameters with <epiparameter> as.function
+  ebola_si_func <- as.function(ebola_si, func_type = "density")
+  cfr_ep_func_density <- cfr_static(
+    data = ebola1976,
+    delay_density = ebola_si_func
+  )
+
+  # check each density function produces the same cfr
+  expect_identical(cfr_base_density, cfr_ep_density)
+  expect_identical(cfr_base_density, cfr_ep_func_density)
+})

--- a/tests/testthat/test-epiparameter-cfr.R
+++ b/tests/testthat/test-epiparameter-cfr.R
@@ -1,23 +1,24 @@
-# load a single Ebola serial interval (SI) from {epiparameter} database
-ebola_si <- epiparameter::epiparameter_db(
+# load a single Ebola onset-to-death delay distribution from {epiparameter}
+# database
+ebola_onset_to_death <- epiparameter::epiparameter_db(
   disease = "Ebola",
-  epi_name = "serial interval",
+  epi_name = "onset-to-death",
   single_epiparameter = TRUE
 )
 
-# check the Ebola SI selected is Gamma, this may change in future versions of
-# {epiparameter} with new entries in the database. The tests will have to be
-# updated if the distribution selected from the database changes.
-family(ebola_si)
+# check the Ebola onset-to-death selected is Gamma, this may change in future
+# versions of {epiparameter} with new entries in the database. The tests will
+# have to be updated if the distribution selected from the database changes
+family(ebola_onset_to_death)
 
-# get parameters from Ebola SI
-dist_params <- epiparameter::get_parameters(ebola_si)
+# get parameters from Ebola onset-to-death
+dist_params <- epiparameter::get_parameters(ebola_onset_to_death)
 
 # load Ebola dataset from {cfr}
 data("ebola1976", package = "cfr")
 
 test_that("cfr_static is works with base and <epiparameter>", {
-  # calculate cfr using Ebola SI parameters with base density
+  # calculate cfr using Ebola onset-to-death parameters with base density
   cfr_base_density <- cfr::cfr_static(
     data = ebola1976,
     delay_density = function(x) {
@@ -25,19 +26,24 @@ test_that("cfr_static is works with base and <epiparameter>", {
     }
   )
 
-  # calculate cfr using Ebola SI parameters with <epiparameter> density
+  # calculate cfr using Ebola onset-to-death parameters with <epiparameter>
+  # density
   cfr_ep_density <- cfr::cfr_static(
     data = ebola1976,
     delay_density = function(x) {
-      density(ebola_si, at = x)
+      density(ebola_onset_to_death, at = x)
     }
   )
 
-  # calculate cfr using Ebola SI parameters with <epiparameter> as.function
-  ebola_si_func <- as.function(ebola_si, func_type = "density")
+  # calculate cfr using Ebola onset-to-death parameters with <epiparameter>
+  # as.function
+  ebola_onset_to_death_func <- as.function(
+    ebola_onset_to_death,
+    func_type = "density"
+  )
   cfr_ep_func_density <- cfr::cfr_static(
     data = ebola1976,
-    delay_density = ebola_si_func
+    delay_density = ebola_onset_to_death_func
   )
 
   # check each density function produces the same cfr

--- a/tests/testthat/test-epiparameter-cfr.R
+++ b/tests/testthat/test-epiparameter-cfr.R
@@ -1,5 +1,5 @@
 # load a single Ebola serial interval (SI) from {epiparameter} database
-ebola_si <- epiparameter_db(
+ebola_si <- epiparameter::epiparameter_db(
   disease = "Ebola",
   epi_name = "serial interval",
   single_epiparameter = TRUE
@@ -11,14 +11,14 @@ ebola_si <- epiparameter_db(
 family(ebola_si)
 
 # get parameters from Ebola SI
-dist_params <- get_parameters(ebola_si)
+dist_params <- epiparameter::get_parameters(ebola_si)
 
 # load Ebola dataset from {cfr}
 data("ebola1976", package = "cfr")
 
 test_that("cfr_static is works with base and <epiparameter>", {
   # calculate cfr using Ebola SI parameters with base density
-  cfr_base_density <- cfr_static(
+  cfr_base_density <- cfr::cfr_static(
     data = ebola1976,
     delay_density = function(x) {
       dgamma(x, shape = dist_params[["shape"]], scale = dist_params[["scale"]])
@@ -26,7 +26,7 @@ test_that("cfr_static is works with base and <epiparameter>", {
   )
 
   # calculate cfr using Ebola SI parameters with <epiparameter> density
-  cfr_ep_density <- cfr_static(
+  cfr_ep_density <- cfr::cfr_static(
     data = ebola1976,
     delay_density = function(x) {
       density(ebola_si, at = x)
@@ -35,7 +35,7 @@ test_that("cfr_static is works with base and <epiparameter>", {
 
   # calculate cfr using Ebola SI parameters with <epiparameter> as.function
   ebola_si_func <- as.function(ebola_si, func_type = "density")
-  cfr_ep_func_density <- cfr_static(
+  cfr_ep_func_density <- cfr::cfr_static(
     data = ebola1976,
     delay_density = ebola_si_func
   )


### PR DESCRIPTION
This PR adds integration tests for the {epiparameter} and {cfr} packages in `test-epiparameter-cfr.R`, using the {testthat} framework.