### PR TITLE
Add integration tests for `simulist::messy_linelist()` and `cleanepi::replace_missing_values()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Suggests:
     spelling,
     testthat (>= 3.0.0)
 Remotes:
-    epiverse-trace/simulist
+    epiverse-trace/simulist@mixed-messy
 VignetteBuilder: 
     knitr
 Config/Needs/website:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,8 +30,6 @@ Suggests:
     rmarkdown,
     spelling,
     testthat (>= 3.0.0)
-Remotes:
-    epiverse-trace/simulist@mixed-messy
 VignetteBuilder: 
     knitr
 Config/Needs/website:

--- a/tests/testthat/test-simulist-cleanepi.R
+++ b/tests/testthat/test-simulist-cleanepi.R
@@ -82,3 +82,90 @@ test_that("find_duplicates corrects prop_duplicate_row", {
   expect_identical(ll, clean_ll)
 })
 
+test_that("replace_missing_values corrects missing data", {
+  # create messy data with 50% of cells missing (i.e. replaced with "NA")
+  expect_warning(
+    messy_ll <- simulist::messy_linelist(
+      linelist = ll,
+      prop_missing = 0.5,
+      missing_value = "NA",
+      prop_spelling_mistakes = 0,
+      inconsistent_sex = FALSE,
+      numeric_as_char = FALSE,
+      date_as_char = FALSE,
+      prop_int_as_word = 0,
+      prop_duplicate_row = 0
+    ),
+    regexp = "(The linelist columns:)*(are being coerced to character)"
+  )
+
+  # convert "NA" values to NA
+  clean_ll <- cleanepi::replace_missing_values(data = messy_ll)
+
+  # check whether report is created as expected
+  report <- attr(clean_ll, "report")
+  expect_identical(names(report), "missing_values_replaced_at")
+  expect_identical(
+    report$missing_values_replaced_at,
+    c("id", "case_name", "case_type", "sex", "age", "date_onset",
+      "date_reporting", "date_admission", "outcome", "date_outcome",
+      "date_first_contact", "date_last_contact", "ct_value")
+  )
+
+  # the index of the "NA" values in the messy data should be a subset of the
+  # NA indices in the cleaned data (subset and not equal because there are NA
+  # values already in the messy data, e.g. $date_admission)
+  expect_true(
+    all(which(messy_ll == "NA") %in% which(is.na(clean_ll)))
+  )
+
+  # all of the "NA"s are replaced in cleaned data
+  expect_false(any(clean_ll == "NA", na.rm = TRUE))
+})
+
+test_that("replace_missing_values corrects multiple missing data values", {
+  # create messy data with 50% of cells missing
+  expect_warning(
+    messy_ll <- simulist::messy_linelist(
+      linelist = ll,
+      prop_missing = 0.5,
+      missing_value = c("N/A", "missing", "not available"),
+      prop_spelling_mistakes = 0,
+      inconsistent_sex = FALSE,
+      numeric_as_char = FALSE,
+      date_as_char = FALSE,
+      prop_int_as_word = 0,
+      prop_duplicate_row = 0
+    ),
+    regexp = "(The linelist columns:)*(are being coerced to character)"
+  )
+
+  # convert "NA" values to NA
+  clean_ll <- cleanepi::replace_missing_values(data = messy_ll)
+
+  # check whether report is created as expected
+  report <- attr(clean_ll, "report")
+  expect_identical(names(report), "missing_values_replaced_at")
+  expect_identical(
+    report$missing_values_replaced_at,
+    c("id", "case_name", "case_type", "sex", "age", "date_onset",
+      "date_reporting", "date_admission", "outcome", "date_outcome",
+      "date_first_contact", "date_last_contact", "ct_value")
+  )
+
+  # the index of the missing values in the messy data should be a subset of the
+  # NA indices in the cleaned data (subset and not equal because there are NA
+  # values already in the messy data, e.g. $date_admission)
+  expect_true(
+    all(
+      which(
+        messy_ll == "N/A" | messy_ll == "missing" | messy_ll == "not available"
+      ) %in% which(is.na(clean_ll))
+    )
+  )
+
+  # all of the missing values are replaced in cleaned data
+  expect_false(any(clean_ll == "N/A", na.rm = TRUE))
+  expect_false(any(clean_ll == "missing", na.rm = TRUE))
+  expect_false(any(clean_ll == "not available", na.rm = TRUE))
+})


### PR DESCRIPTION
This PR adds integration tests for the {simulist} function `messy_linelist()` and {cleanepi} function `replace_missing_values()` in `test-simulist-cleanepi.R`. 

It adds a unit test for the simple case of a single missing value to generate messy data, and a unit test for the new feature in {simulist} to have multiple missing values in the messy data. 

~~***Blocker***: this branch is temporarily depending on the `mixed-messy` {simulist} branch. **Do not merge** until the new version of {simulist} has been released and this PR has been updated to depend on the CRAN version of {simulist}.~~ 
{simulist} v0.6.0 now released on CRAN.